### PR TITLE
Replace hyphens with underscores in generated Android asset paths

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -1,5 +1,5 @@
 {
-    "id": "io.supernova.android-assets",
+    "id": "com.usertesting.android-assets-exporter",
     "name": "Android Assets",
     "description": "Export vector assets for Android",
     "author": "Jiri Trecak",

--- a/src/asset_path_android.pr
+++ b/src/asset_path_android.pr
@@ -15,10 +15,10 @@
 
 {* Generate name as [originalName][-numberOfDuplicates][extension] *}
 {[ let duplicateExtension = (asset.previouslyDuplicatedNames > 0 ? ("_" + asset.previouslyDuplicatedNames) : "") /]}
-{[ let name = (asset.originalName.lowercased().replacing(" ", "_") + duplicateExtension + "." + asset.format) /]}
+{[ let name = (asset.originalName.lowercased().replacing(" ", "_").replacing("-", "_") + duplicateExtension + "." + asset.format) /]}
 
 {* Generate path from segments *}
-{[ let path = (asset.group.path.append(asset.group.name).join("_").replacing(" ", "_").lowercased()) /]}
+{[ let path = (asset.group.path.append(asset.group.name).join("_").replacing(" ", "_").replacing("-", "_").lowercased()) /]}
 {[ log path /]}
 
 {* Retrieve asset path *}


### PR DESCRIPTION
Asset names containing hyphens produced invalid Android resource names. Added .replacing("-", "_") to both the file name and group path construction to ensure all output paths are valid.
